### PR TITLE
Add custom network binding documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Go Backend
 - **Development**: `go run . serve` - Runs the PocketBase server with hot reload
+- **Custom network binding**: `go run . serve --http="192.168.100.100:8090"` - Bind to specific IP and port
 - **Install dependencies**: `go mod tidy`
 - **Production build**: `GOOS=linux GOARCH=amd64 go build -ldflags "-s -w"`
 - **Update dependencies**: `go get -u -t ./... && go mod tidy`

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ cd ui && npm install
 # Run development server with hot reload
 go run . serve
 
+# Run with custom network binding (specific IP and port)
+go run . serve --http="192.168.100.100:8090"
+
 # Frontend development (separate terminal)
 cd ui && npm run dev
 ```


### PR DESCRIPTION
Update CLAUDE.md and README.md to include instructions for running the server with custom network binding (specific IP and port).

🤖 Generated with [Claude Code](https://claude.com/claude-code)